### PR TITLE
Update README.md, remove the (hopefully) loads first

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ QPIP handles each plugin independently. If two plugins have incomptabile require
 
 ## How it works internally
 
-- QPIP is installed under the `a00_qpip` directory, so that it (hopefully) loads first
+- QPIP is installed under the `a00_qpip` directory and it will load before any dependent plugin
 - `USERPROFILE/python/dependencies/Lib/site-packages` is added to sys.path
 - `USERPROFILE/python/dependencies/Scripts` is added to the PATH
 - `qgis.utils.loadPlugin` is monkeypatched, injecting code that checks requirements in `requirements.txt` using `pkg_resources`


### PR DESCRIPTION
Since https://github.com/qgis/QGIS/pull/44906, all dependent plugins will be loaded after their dependencies.

Fix #10 