### PR TITLE
Fix table background in dark theme

### DIFF
--- a/a00_qpip/ui.py
+++ b/a00_qpip/ui.py
@@ -82,8 +82,11 @@ class MainDialog(QDialog):
             self.action_combos[lib] = action_combo
 
             # row color (gray out system deps)
-            row_color = QgsApplication.palette().base().color() if lib.qpip \
+            row_color = (
+                QgsApplication.palette().base().color()
+                if lib.qpip
                 else QColor("#aaaaaa")
+            )
             for j in range(0, 5):
                 self.table_widget.item(i, j).setBackground(row_color)
 

--- a/a00_qpip/ui.py
+++ b/a00_qpip/ui.py
@@ -82,7 +82,8 @@ class MainDialog(QDialog):
             self.action_combos[lib] = action_combo
 
             # row color (gray out system deps)
-            row_color = QColor("#ffffff") if lib.qpip else QColor("#aaaaaa")
+            row_color = QgsApplication.palette().base().color() if lib.qpip \
+                else QColor("#aaaaaa")
             for j in range(0, 5):
                 self.table_widget.item(i, j).setBackground(row_color)
 

--- a/a00_qpip/ui_dialog.ui
+++ b/a00_qpip/ui_dialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>683</width>
+    <width>780</width>
     <height>387</height>
    </rect>
   </property>


### PR DESCRIPTION
Gets the default cell background from the current palette. Also makes the dialog ~100px wider as the table contents couldn't fit.

# Before:
  ![before](https://github.com/user-attachments/assets/11d00763-f322-47e3-897a-ff6f37f85556)


# After - dark:
  ![after_dark](https://github.com/user-attachments/assets/46e332fc-a7f8-49b7-a02a-e654c6b585c1)


# After - light:
   ![after_light](https://github.com/user-attachments/assets/7fa49dcd-ffbc-4927-8ce4-392f862dd736)


