### PR TITLE
Add support for dependency check while installing a plugin

### DIFF
--- a/a00_qpip/plugin.py
+++ b/a00_qpip/plugin.py
@@ -11,7 +11,7 @@ import qgis
 from pkg_resources import DistributionNotFound, VersionConflict
 from pyplugin_installer import installer
 from qgis.core import QgsApplication, QgsSettings
-from qgis.PyQt.QtWidgets import QAction
+from qgis.PyQt.QtWidgets import QAction, QApplication
 
 from .ui import MainDialog
 from .utils import Lib, Req, icon, log, run_cmd
@@ -107,25 +107,34 @@ class Plugin:
         """
         This replaces qgis.utils.loadPlugin
         """
+        res = False
+
+        # Get override cursor if any, to restore it later
+        cursor_shape = None
+        cursor = QApplication.overrideCursor()
+        if cursor:
+            cursor_shape = cursor.shape()
+            QApplication.restoreOverrideCursor()
+
         if not self._is_qgis_loaded():
             # During QGIS startup
             log(f"Loading {packageName} (GUI is no yet ready).")
             if not self._check_on_startup():
                 # With initial loading disabled, we simply load the plugin
                 log(f"Check on startup disabled. Normal loading of {packageName}.")
-                return self._original_loadPlugin(packageName)
+                res = self._original_loadPlugin(packageName)
             else:
                 # With initial loading enabled, we defer loading
                 log(f"Check on startup enabled, we defer loading of {packageName}.")
                 self._defered_packages.append(packageName)
-                return False
+                res = False
         else:
             # QGIS ready, a plugin probably was just enabled in the manager
             log(f"Loading {packageName} (GUI is ready).")
             if not self._check_on_install():
                 # With loading on install disabled, we simply load the plugin
                 log(f"Check on install disabled. Normal loading of {packageName}.")
-                return self._original_loadPlugin(packageName)
+                res = self._original_loadPlugin(packageName)
             else:
                 log(f"Check on install enabled, we check {packageName}.")
                 dialog, run_gui = self.check_deps(additional_plugins=[packageName])
@@ -133,7 +142,13 @@ class Plugin:
                     self.promt_install(dialog)
                 self.save_settings(dialog)
                 self.start_packages([packageName])
-                return True
+                res = True
+
+        # Restore original cursor
+        if cursor_shape:
+            QApplication.setOverrideCursor(cursor_shape)
+
+        return res
 
     def check_deps(self, additional_plugins=[]) -> Union[MainDialog, bool]:
         """


### PR DESCRIPTION
In this way, QPIP will not only check deps when a plugin is activated/loaded, but also when it's installed (either via plugin repo or via ZIP).

This avoids getting `Module Not Found` errors when a plugin is installed and calling its `classFactory()` already imports  other Python deps that are not present in the system.

Also, avoid waiting cursor set by QGIS for plugin installation when QPIP dialog is shown. We save the current cursor when entering the monkey patched `loadPlugin`, and restore it when leaving that method.