### PR TITLE
fix for Qt6 compability, see #39

### DIFF
--- a/a00_qpip/utils.py
+++ b/a00_qpip/utils.py
@@ -85,13 +85,13 @@ def run_cmd(args, description="running a system command"):
     if process.returncode != 0:
         warn(f"Command failed.")
         message = QMessageBox(
-            QMessageBox.Warning,
+            QMessageBox.Icon.Warning,
             "Command failed",
             f"Encountered an error while {description} !",
             parent=iface.mainWindow(),
         )
         message.setDetailedText(full_output)
-        message.exec_()
+        message.exec()
     else:
         log("Command succeeded.")
         iface.messageBar().pushMessage(


### PR DESCRIPTION
PR fixes error on Qgis4:

> File "/home/user/.local/share/QGIS/QGIS3/profiles/default/python/plugins/a00_qpip/utils.py", line 88, in run_cmd QMessageBox.Warning, ^^^^^^^^^^^^^^^^^^^ AttributeError: type object 'QMessageBox' has no attribute 'Warning'. Did you mean: 'warning'?