### PR TITLE
enable sorting for QTableWidget

### DIFF
--- a/a00_qpip/ui_dialog.ui
+++ b/a00_qpip/ui_dialog.ui
@@ -68,6 +68,9 @@
      <property name="textElideMode">
       <enum>Qt::ElideMiddle</enum>
      </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
      <property name="wordWrap">
       <bool>true</bool>
      </property>


### PR DESCRIPTION
Sorting comes in handy for large lists, for example when showing all system deps.