### PR TITLE
Pin dependency installs to versions from the QGIS Python environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ QPIP handles each plugin independently. If two plugins have incomptabile require
 - if requirements are met, the plugin is loaded directly
 - if requirements are not met, the dialog is shown to the user*
   - on confirmation, selected libraries are installed with `pip [...] --prefix USERPROFILE/python/dependencies`
+  - the libraries already provided by the QGIS Python environment are pinned to their installed version (using a pip constraints file), so that their dependencies are not installed in a version that would conflict with the one QGIS uses. If pip finds no solution under those pins, the installation is retried without them.
   - the plugin is then loaded
 
 *during startup (with the `Run QPIP on startup` option), the dialog is deferred to after GUI initialisation

--- a/a00_qpip/plugin.py
+++ b/a00_qpip/plugin.py
@@ -3,14 +3,16 @@ import platform
 import shutil
 import subprocess
 import sys
+import tempfile
 from collections import defaultdict, namedtuple
 from importlib import metadata
 from pathlib import Path
-from typing import Union
+from typing import List, Union
 
 import qgis
 from packaging.markers import default_environment
-from packaging.requirements import Requirement
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
 from packaging.version import Version
 from pyplugin_installer import installer
 from qgis.core import QgsApplication, QgsSettings
@@ -310,10 +312,42 @@ class Plugin:
     def pip_install_reqs(self, reqs_to_install):
         """
         Installs given reqs with pip
+
+        Dependencies already provided by the QGIS Python environment are pinned to
+        their installed version, so we don't end up with two incompatible versions
+        of the same library in the same session. If pip finds no solution under
+        those pins, the installation is retried without them.
         """
         self.prefix_path.mkdir(parents=True, exist_ok=True)
         log(f"Will pip install {reqs_to_install}")
 
+        already_installed = self.check_already_installed(
+            reqs_to_install=reqs_to_install
+        )
+
+        constraints = self.environment_constraints(reqs_to_install)
+
+        succeeded = self.run_pip_install(
+            reqs_to_install, constraints, report_errors=not constraints
+        )
+        if not succeeded and constraints:
+            warn(
+                "Installing with the versions provided by QGIS failed. Retrying "
+                "without them, which may install libraries incompatible with QGIS."
+            )
+            self.run_pip_install(reqs_to_install, [])
+
+        # if the package has been installed before, prompt user to restart
+        if already_installed:
+            self.show_restart_message()
+
+    def run_pip_install(
+        self, reqs_to_install, constraints: List[str], report_errors=True
+    ) -> bool:
+        """
+        Runs pip install for the given reqs, optionally under the given
+        constraints, and returns whether it succeeded.
+        """
         cmd = [
             self.python_command(),
             "-um",
@@ -325,20 +359,54 @@ class Plugin:
             "--upgrade",
         ]
 
-        # check to see if any dependencies have versions already installed - if it is, we need to propose a restart
-        already_installed = self.check_already_installed(
-            reqs_to_install=reqs_to_install
-        )
+        with tempfile.TemporaryDirectory(prefix="qpip-") as temp_dir:
+            if constraints:
+                constraints_path = Path(temp_dir) / "constraints.txt"
+                constraints_path.write_text("\n".join(constraints) + "\n")
+                cmd.extend(["--constraint", str(constraints_path)])
+                log(f"Constraining install to {len(constraints)} installed versions")
 
-        # run the installed command
-        run_cmd(
-            cmd,
-            f"installing {len(reqs_to_install)} requirements",
-        )
+            return run_cmd(
+                cmd,
+                f"installing {len(reqs_to_install)} requirements",
+                report_errors=report_errors,
+            )
 
-        # if the package has been installed before, prompt user to restart
-        if already_installed:
-            self.show_restart_message()
+    def environment_constraints(self, reqs_to_install) -> List[str]:
+        """
+        Returns pip constraints pinning the libraries provided by the QGIS Python
+        environment to the version currently installed.
+
+        Without those, installing into the QPIP folder resolves the dependencies of
+        the requirements to their latest version, which then shadow the ones shipped
+        with QGIS and may be incompatible with them.
+
+        Libraries installed by QPIP itself and libraries explicitly requested by a
+        plugin are left out, so they can still be installed or upgraded freely.
+        """
+        requested = {
+            canonicalize_name(Requirement(req).name) for req in reqs_to_install
+        }
+
+        # metadata.distributions() follows sys.path order, so the first distribution
+        # found for a library is the one that gets imported
+        constraints = {}
+        for dist in metadata.distributions():
+            name = dist.metadata["Name"]
+            version = dist.metadata["Version"]
+            if not name or not version:
+                continue
+            key = canonicalize_name(name)
+            if key in requested or key in constraints:
+                continue
+            if Path(str(dist._path)).parent == self.site_packages_path:
+                continue
+            try:
+                constraints[key] = str(Requirement(f"{name}=={version}"))
+            except InvalidRequirement:
+                log(f"Cannot pin {name} to version {version}. Skipping...")
+
+        return sorted(constraints.values(), key=str.lower)
 
     def qpip_installed_packages(self):
         return [

--- a/a00_qpip/utils.py
+++ b/a00_qpip/utils.py
@@ -46,7 +46,14 @@ def icon(name):
     return QIcon(os.path.join(os.path.dirname(__file__), "icons", name))
 
 
-def run_cmd(args, description="running a system command"):
+def run_cmd(args, description="running a system command", report_errors=True) -> bool:
+    """
+    Runs a command, showing a progress dialog.
+
+    Returns whether the command succeeded. Failures are reported to the user
+    unless `report_errors` is False, which allows the caller to retry with
+    another command before bothering the user.
+    """
     progress_dlg = QProgressDialog(
         description, "Abort", 0, 0, parent=iface.mainWindow()
     )
@@ -90,15 +97,16 @@ def run_cmd(args, description="running a system command"):
     progress_dlg.close()
 
     if process.returncode != 0:
-        warn(f"Command failed.")
-        message = QMessageBox(
-            QMessageBox.Icon.Warning,
-            "Command failed",
-            f"Encountered an error while {description} !",
-            parent=iface.mainWindow(),
-        )
-        message.setDetailedText(full_output)
-        message.exec()
+        warn("Command failed.")
+        if report_errors:
+            message = QMessageBox(
+                QMessageBox.Icon.Warning,
+                "Command failed",
+                f"Encountered an error while {description} !",
+                parent=iface.mainWindow(),
+            )
+            message.setDetailedText(full_output)
+            message.exec()
     else:
         log("Command succeeded.")
         iface.messageBar().pushMessage(
@@ -106,3 +114,5 @@ def run_cmd(args, description="running a system command"):
             f"{description.capitalize()} succeeded",
             level=Qgis.Success,
         )
+
+    return process.returncode == 0

--- a/tests/test_environment_constraints.py
+++ b/tests/test_environment_constraints.py
@@ -1,0 +1,140 @@
+"""
+Tests for the pip constraints built from the QGIS Python environment.
+
+These tests verify that:
+- Libraries installed in the QGIS Python environment are pinned to their version
+- Libraries installed by QPIP itself are not pinned, so they can be upgraded
+- Libraries explicitly required by a plugin are not pinned
+- Unusable distributions (no name, no version, unpinnable version) are skipped
+- The constraints are passed to pip, and dropped if pip can't resolve them
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from a00_qpip.plugin import Plugin
+
+SYSTEM_PATH = "/usr/lib/python3/dist-packages"
+
+
+class initializationCompleted:
+    def connect(self):
+        pass
+
+
+def popWidget():
+    return True
+
+
+class FakeDistribution:
+    """Minimal stand-in for importlib.metadata.Distribution."""
+
+    def __init__(self, name, version, path=None):
+        self.metadata = {"Name": name, "Version": version}
+        self._path = path or f"{SYSTEM_PATH}/{name}.dist-info"
+
+
+def fake_distributions(*dists):
+    """Patches the distributions found on sys.path, in sys.path order."""
+    return patch("a00_qpip.plugin.metadata.distributions", return_value=dists)
+
+
+@pytest.fixture()
+def plugin(qgis_iface, tmp_path):
+    """A plugin installing its dependencies in a temporary profile folder."""
+    qgis_iface.initializationCompleted = initializationCompleted
+    qgis_iface.messageBar().popWidget = popWidget
+    with patch(
+        "a00_qpip.plugin.QgsApplication.qgisSettingsDirPath",
+        return_value=str(tmp_path),
+    ):
+        return Plugin(qgis_iface, str(tmp_path / "python" / "plugins"))
+
+
+def test_pins_environment_libraries(plugin: Plugin):
+    """Libraries found outside the QPIP folder are pinned to their version."""
+    with fake_distributions(
+        FakeDistribution("numpy", "1.24.4"),
+        FakeDistribution("Pandas", "2.0.3"),
+    ):
+        constraints = plugin.environment_constraints([])
+
+    assert constraints == ["numpy==1.24.4", "Pandas==2.0.3"]
+
+
+def test_skips_qpip_installed_libraries(plugin: Plugin):
+    """Libraries installed by QPIP are not pinned, so they can be upgraded."""
+    qpip_dist = str(plugin.site_packages_path / "cowsay-4.0.dist-info")
+    with fake_distributions(
+        FakeDistribution("cowsay", "4.0", qpip_dist),
+        FakeDistribution("numpy", "1.24.4"),
+    ):
+        constraints = plugin.environment_constraints([])
+
+    assert constraints == ["numpy==1.24.4"]
+
+
+def test_skips_requested_libraries(plugin: Plugin):
+    """Libraries a plugin asks for are not pinned to the installed version."""
+    with fake_distributions(
+        FakeDistribution("cow-say", "4.0"),
+        FakeDistribution("numpy", "1.24.4"),
+    ):
+        constraints = plugin.environment_constraints(["cow_say==5.0"])
+
+    assert constraints == ["numpy==1.24.4"]
+
+
+def test_keeps_first_of_duplicated_libraries(plugin: Plugin):
+    """When a library is installed twice, the version that gets imported wins."""
+    with fake_distributions(
+        FakeDistribution("numpy", "1.24.4", "/first/on/sys/path/numpy.dist-info"),
+        FakeDistribution("numpy", "1.21.0", "/later/on/sys/path/numpy.dist-info"),
+    ):
+        constraints = plugin.environment_constraints([])
+
+    assert constraints == ["numpy==1.24.4"]
+
+
+def test_skips_unusable_distributions(plugin: Plugin):
+    """Distributions without metadata or with an unpinnable version are skipped."""
+    with fake_distributions(
+        FakeDistribution(None, "1.0", f"{SYSTEM_PATH}/unnamed.dist-info"),
+        FakeDistribution("unversioned", None),
+        FakeDistribution("broken", "not a version"),
+        FakeDistribution("numpy", "1.24.4"),
+    ):
+        constraints = plugin.environment_constraints([])
+
+    assert constraints == ["numpy==1.24.4"]
+
+
+def test_install_passes_constraints_to_pip(plugin: Plugin):
+    """The constraints are written to a file passed to pip."""
+    with patch("a00_qpip.plugin.run_cmd", return_value=True) as run_cmd:
+        plugin.run_pip_install(["cowsay==4.0"], ["numpy==1.24.4"])
+
+    cmd = run_cmd.call_args[0][0]
+    assert cmd[cmd.index("--constraint") + 1].endswith("constraints.txt")
+
+
+def test_install_retries_without_constraints(plugin: Plugin):
+    """If pip can't resolve the constraints, the install is retried without them."""
+    with patch.object(plugin, "environment_constraints", return_value=["numpy==1.0"]):
+        with patch("a00_qpip.plugin.run_cmd", return_value=False) as run_cmd:
+            plugin.pip_install_reqs(["cowsay==4.0"])
+
+    first_cmd, second_cmd = (call[0][0] for call in run_cmd.call_args_list)
+    assert "--constraint" in first_cmd
+    assert "--constraint" not in second_cmd
+
+
+def test_install_without_environment_reports_errors(plugin: Plugin):
+    """Without constraints, pip failures are reported to the user right away."""
+    with patch.object(plugin, "environment_constraints", return_value=[]):
+        with patch("a00_qpip.plugin.run_cmd", return_value=False) as run_cmd:
+            plugin.pip_install_reqs(["cowsay==4.0"])
+
+    run_cmd.assert_called_once()
+    assert run_cmd.call_args[1]["report_errors"]


### PR DESCRIPTION
## Summary

- When installing plugin requirements into the QPIP `--target` folder, pip does not consider packages already present in the QGIS Python environment, so transitive dependencies are often resolved to their latest versions.
- Those newer copies can end up earlier on `sys.path` than the ones shipped with QGIS and cause import-time incompatibilities.
- This change builds a temporary pip constraints file from packages installed outside the QPIP folder (pinning `name==version`), passes it via `--constraint`, and retries the install without constraints if resolution fails.

## Motivation / example

On **QGIS 3.40.12 / Python 3.12.11 / Windows**, QGIS ships for example:

- `numpy 1.26.4`
- `scipy 1.13.0`

A plugin may only declare something like `wntr>=1.2.0`. QPIP then installs the latest `wntr`, which depends on `numpy` and `scipy`. Because the install goes into `--target` and does not see the QGIS environment as the resolver context, pip also installs the latest of those transitive deps into the profile dependencies folder, e.g.:

- `numpy 2.5.1`
- `scipy 1.18.0`

At runtime the session mixes both locations. Some libraries are already imported from the QGIS Python environment when QGIS starts (e.g. `numpy`), while others are loaded later from the QPIP folder (e.g. `scipy` / `wntr`). In this case that produced:

```text
AttributeError: module 'numpy' has no attribute 'long'. Did you mean: 'log'?
