### PR TITLE
Fix package name matching with canonicalize_name

### DIFF
--- a/a00_qpip/plugin.py
+++ b/a00_qpip/plugin.py
@@ -11,6 +11,7 @@ from typing import Union
 import qgis
 from packaging.markers import default_environment
 from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 from packaging.version import Version
 from pyplugin_installer import installer
 from qgis.core import QgsApplication, QgsSettings
@@ -196,10 +197,11 @@ class Plugin:
             if not name:
                 log(f"Dist {metadata} does not have a name. Skipping...")
                 continue
-            libs[name].name = name
-            libs[name].installed_dist = dist
+            key = canonicalize_name(name)
+            libs[key].name = name
+            libs[key].installed_dist = dist
             if Path(str(dist._path)).parent != self.site_packages_path:
-                libs[name].qpip = False
+                libs[key].qpip = False
 
         # Checking requirements of all plugins
         needs_gui = False
@@ -238,8 +240,9 @@ class Plugin:
                             )
                             needs_gui = True
                         req = Req(plugin_name, str(requirement), error)
-                        libs[requirement.name].name = requirement.name
-                        libs[requirement.name].required_by.append(req)
+                        key = canonicalize_name(requirement.name)
+                        libs[key].name = requirement.name
+                        libs[key].required_by.append(req)
 
         dialog = MainDialog(
             libs.values(), self._check_on_startup(), self._check_on_install()


### PR DESCRIPTION
## Summary

QPIP indexes installed packages and plugin requirements by the raw package name. When the dist metadata `Name` and the spelling in `requirements.txt` differ only by case or `-`/`_`, they are treated as different keys, so the UI can show a package as not installed even when it is.

This change keys both sides with `packaging.utils.canonicalize_name` so they match on the same row.

## Motivation / example

A plugin may require `pypdf2`, while the installed distribution reports `Name: PyPDF2`. The same happens with names like `netCDF4` vs `netcdf4`. QPIP then shows Required by and Installed on separate rows (or as missing), even though the package is already present.