### PR TITLE
Add per-dependency progress for pip installs

### DIFF
--- a/a00_qpip/install_progress.py
+++ b/a00_qpip/install_progress.py
@@ -1,0 +1,202 @@
+from packaging.utils import canonicalize_name
+from qgis.PyQt.QtCore import QProcess, Qt
+from qgis.PyQt.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QPlainTextEdit,
+    QProgressBar,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
+
+from .pip_progress import PipProgressParser, requirement_name
+
+
+class PipInstallProgressDialog(QDialog):
+    """Run one pip resolver process and expose progress for every dependency."""
+
+    COMPLETE_STATUSES = {"Already installed", "Completed"}
+
+    def __init__(self, args, requirements, description, log_callback, parent=None):
+        super().__init__(parent)
+        self.args = [str(arg) for arg in args]
+        self.description = description
+        self.log_callback = log_callback
+        self.parser = PipProgressParser(requirements)
+        self.rows = {}
+        self.output_buffer = ""
+        self.full_output = ""
+        self.cancelled = False
+        self.exit_code = None
+
+        self.setWindowTitle("QPIP - Python dependency installation")
+        self.setWindowModality(Qt.WindowModality.WindowModal)
+        self.resize(720, 430)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel(description.capitalize()))
+
+        self.table = QTableWidget(0, 3)
+        self.table.setHorizontalHeaderLabels(["Dependency", "Status", "Progress"])
+        self.table.horizontalHeader().setStretchLastSection(True)
+        self.table.verticalHeader().setVisible(False)
+        layout.addWidget(self.table)
+
+        layout.addWidget(QLabel("Overall progress"))
+        self.overall_progress = QProgressBar()
+        layout.addWidget(self.overall_progress)
+
+        self.details = QPlainTextEdit()
+        self.details.setReadOnly(True)
+        self.details.setVisible(False)
+        self.details.setMaximumBlockCount(2000)
+        layout.addWidget(self.details)
+
+        buttons = QHBoxLayout()
+        self.details_button = QPushButton("Show details")
+        self.details_button.setCheckable(True)
+        self.details_button.toggled.connect(self._toggle_details)
+        buttons.addWidget(self.details_button)
+        buttons.addStretch()
+        self.abort_button = QPushButton("Abort")
+        self.abort_button.clicked.connect(self._abort)
+        buttons.addWidget(self.abort_button)
+        layout.addLayout(buttons)
+
+        for requirement in requirements:
+            self._ensure_row(requirement_name(requirement), "Pending")
+
+        self.process = QProcess(self)
+        channel_mode = getattr(QProcess, "MergedChannels", None)
+        if channel_mode is None:
+            channel_mode = QProcess.ProcessChannelMode.MergedChannels
+        self.process.setProcessChannelMode(channel_mode)
+        self.process.readyReadStandardOutput.connect(self._read_output)
+        self.process.finished.connect(self._finished)
+        self.process.errorOccurred.connect(self._process_error)
+
+    def execute(self):
+        self.process.start(self.args[0], self.args[1:])
+        self.exec()
+        return self.exit_code, self.cancelled, self.full_output
+
+    def _ensure_row(self, package, status="Pending"):
+        key = canonicalize_name(package)
+        if key in self.rows:
+            return self.rows[key]
+
+        row = self.table.rowCount()
+        self.table.insertRow(row)
+        self.table.setItem(row, 0, QTableWidgetItem(package))
+        self.table.setItem(row, 1, QTableWidgetItem(status))
+        progress = QProgressBar()
+        progress.setRange(0, 0 if status in {"Resolving", "Installing"} else 100)
+        progress.setValue(0)
+        progress.setTextVisible(status not in {"Resolving", "Installing"})
+        self.table.setCellWidget(row, 2, progress)
+        self.rows[key] = (row, progress)
+        self.table.resizeColumnToContents(0)
+        self._update_overall()
+        return row, progress
+
+    def _apply_update(self, update):
+        if update.package is None:
+            return
+
+        row, progress = self._ensure_row(update.package, update.status)
+        self.table.item(row, 1).setText(update.status)
+
+        if update.total:
+            progress.setRange(0, update.total)
+            progress.setValue(min(update.current or 0, update.total))
+            progress.setTextVisible(True)
+        elif update.status in {"Resolving", "Downloading", "Installing", "Using cache"}:
+            progress.setRange(0, 0)
+            progress.setTextVisible(False)
+
+        if update.status in self.COMPLETE_STATUSES:
+            progress.setRange(0, 1)
+            progress.setValue(1)
+            progress.setTextVisible(True)
+
+        self._update_overall()
+
+    def _update_overall(self):
+        total = len(self.rows)
+        completed = 0
+        for row, _progress in self.rows.values():
+            if self.table.item(row, 1).text() in self.COMPLETE_STATUSES:
+                completed += 1
+        self.overall_progress.setRange(0, max(total, 1))
+        self.overall_progress.setValue(completed)
+        self.overall_progress.setFormat(
+            f"{completed} of {total} dependencies completed"
+        )
+
+    def _read_output(self):
+        chunk = bytes(self.process.readAllStandardOutput()).decode(errors="replace")
+        if not chunk:
+            return
+        self.full_output += chunk
+        self.output_buffer += chunk.replace("\r", "\n")
+        lines = self.output_buffer.split("\n")
+        self.output_buffer = lines.pop()
+        for line in lines:
+            self._consume_line(line)
+
+    def _consume_line(self, line):
+        line = line.strip()
+        if not line:
+            return
+        self.details.appendPlainText(line)
+        self.log_callback(line)
+        for update in self.parser.parse_line(line):
+            self._apply_update(update)
+
+    def _finished(self, exit_code, _exit_status):
+        self._read_output()
+        if self.output_buffer.strip():
+            self._consume_line(self.output_buffer)
+            self.output_buffer = ""
+        self.exit_code = exit_code
+        self.abort_button.setEnabled(False)
+        if exit_code == 0:
+            for row, progress in self.rows.values():
+                self.table.item(row, 1).setText("Completed")
+                progress.setRange(0, 1)
+                progress.setValue(1)
+                progress.setTextVisible(True)
+            self._update_overall()
+            self.accept()
+        else:
+            self.reject()
+
+    def _process_error(self, _error):
+        error = self.process.errorString()
+        if error:
+            self.full_output += error
+            self.details.appendPlainText(error)
+            self.log_callback(error)
+        self.abort_button.setEnabled(False)
+        if self.process.state() == QProcess.ProcessState.NotRunning:
+            self.exit_code = -1
+            self.reject()
+
+    def _abort(self):
+        self.cancelled = True
+        self.abort_button.setEnabled(False)
+        self.abort_button.setText("Aborting...")
+        self.process.kill()
+
+    def _toggle_details(self, visible):
+        self.details.setVisible(visible)
+        self.details_button.setText("Hide details" if visible else "Show details")
+
+    def reject(self):
+        if self.process.state() != QProcess.ProcessState.NotRunning:
+            self._abort()
+            return
+        super().reject()

--- a/a00_qpip/install_progress.py
+++ b/a00_qpip/install_progress.py
@@ -110,8 +110,9 @@ class PipInstallProgressDialog(QDialog):
         self.table.item(row, 1).setText(update.status)
 
         if update.total:
-            progress.setRange(0, update.total)
-            progress.setValue(min(update.current or 0, update.total))
+            percentage = min(100, int(100 * (update.current or 0) / update.total))
+            progress.setRange(0, 100)
+            progress.setValue(percentage)
             progress.setTextVisible(True)
         elif update.status in {"Resolving", "Downloading", "Installing", "Using cache"}:
             progress.setRange(0, 0)
@@ -172,6 +173,7 @@ class PipInstallProgressDialog(QDialog):
             self._update_overall()
             self.accept()
         else:
+            self._mark_unfinished("Cancelled" if self.cancelled else "Error")
             self.reject()
 
     def _process_error(self, _error):
@@ -183,13 +185,23 @@ class PipInstallProgressDialog(QDialog):
         self.abort_button.setEnabled(False)
         if self.process.state() == QProcess.ProcessState.NotRunning:
             self.exit_code = -1
+            self._mark_unfinished("Cancelled" if self.cancelled else "Error")
             self.reject()
 
     def _abort(self):
         self.cancelled = True
         self.abort_button.setEnabled(False)
         self.abort_button.setText("Aborting...")
+        self._mark_unfinished("Cancelling")
         self.process.kill()
+
+    def _mark_unfinished(self, status):
+        for row, progress in self.rows.values():
+            if self.table.item(row, 1).text() not in self.COMPLETE_STATUSES:
+                self.table.item(row, 1).setText(status)
+                progress.setRange(0, 1)
+                progress.setValue(0)
+                progress.setTextVisible(False)
 
     def _toggle_details(self, visible):
         self.details.setVisible(visible)

--- a/a00_qpip/pip_progress.py
+++ b/a00_qpip/pip_progress.py
@@ -1,0 +1,117 @@
+import re
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import List, Optional
+from urllib.parse import urlsplit
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import (
+    canonicalize_name,
+    parse_sdist_filename,
+    parse_wheel_filename,
+)
+
+
+@dataclass(frozen=True)
+class ProgressUpdate:
+    package: Optional[str]
+    status: str
+    current: Optional[int] = None
+    total: Optional[int] = None
+
+
+def requirement_name(requirement: str) -> str:
+    """Return a stable display name for a PEP 508 or legacy pip argument."""
+    try:
+        return Requirement(requirement).name
+    except InvalidRequirement:
+        value = requirement.split(";", 1)[0].strip()
+        value = value.split(" @ ", 1)[0].strip()
+        match = re.match(r"[A-Za-z0-9][A-Za-z0-9_.-]*", value)
+        return match.group(0) if match else value
+
+
+def package_from_download(value: str) -> Optional[str]:
+    """Extract a distribution name from a pip download URL or filename."""
+    filename = PurePosixPath(urlsplit(value).path).name
+    if filename.endswith(".metadata"):
+        filename = filename[: -len(".metadata")]
+
+    try:
+        if filename.endswith(".whl"):
+            return str(parse_wheel_filename(filename)[0])
+        return str(parse_sdist_filename(filename)[0])
+    except (InvalidRequirement, ValueError):
+        return None
+
+
+class PipProgressParser:
+    """Convert pip's line-oriented output into package progress updates."""
+
+    _collecting = re.compile(r"^Collecting\s+(.+?)(?:\s+\(from .*)?$")
+    _already = re.compile(r"^Requirement already satisfied:\s+([^\s,]+)")
+    _download = re.compile(r"^(?:Downloading|Using cached)\s+(\S+)")
+    _raw_progress = re.compile(r"^Progress\s+(\d+)\s+of\s+(\d+)$")
+    _installing = re.compile(r"^Installing collected packages:\s*(.+)$")
+
+    def __init__(self, requirements=()):
+        self.known_names = {}
+        for requirement in requirements:
+            self._remember(requirement_name(requirement))
+        self.active_download = None
+        self.installing = []
+
+    def _remember(self, name: str) -> str:
+        key = canonicalize_name(name)
+        self.known_names.setdefault(key, name)
+        return self.known_names[key]
+
+    def parse_line(self, line: str) -> List[ProgressUpdate]:
+        line = line.strip()
+        if not line:
+            return []
+
+        match = self._collecting.match(line)
+        if match:
+            name = self._remember(requirement_name(match.group(1)))
+            return [ProgressUpdate(name, "Resolving")]
+
+        match = self._already.match(line)
+        if match:
+            name = self._remember(requirement_name(match.group(1)))
+            return [ProgressUpdate(name, "Already installed", 1, 1)]
+
+        match = self._download.match(line)
+        if match:
+            name = package_from_download(match.group(1))
+            if name:
+                name = self._remember(name)
+                self.active_download = name
+                status = (
+                    "Using cache" if line.startswith("Using cached") else "Downloading"
+                )
+                return [ProgressUpdate(name, status)]
+            return []
+
+        match = self._raw_progress.match(line)
+        if match and self.active_download:
+            current, total = (int(value) for value in match.groups())
+            status = "Downloaded" if total and current >= total else "Downloading"
+            return [ProgressUpdate(self.active_download, status, current, total)]
+
+        match = self._installing.match(line)
+        if match:
+            self.installing = [
+                self._remember(name.strip())
+                for name in match.group(1).split(",")
+                if name.strip()
+            ]
+            return [ProgressUpdate(name, "Installing") for name in self.installing]
+
+        if line.startswith("Successfully installed"):
+            return [ProgressUpdate(name, "Completed", 1, 1) for name in self.installing]
+
+        if line.startswith("ERROR:"):
+            return [ProgressUpdate(None, "Error")]
+
+        return []

--- a/a00_qpip/plugin.py
+++ b/a00_qpip/plugin.py
@@ -337,7 +337,6 @@ class Plugin:
         installed = run_pip_install(
             cmd,
             reqs_to_install,
-            f"installing {len(reqs_to_install)} requirements",
         )
 
         # if the package has been installed before, prompt user to restart

--- a/a00_qpip/plugin.py
+++ b/a00_qpip/plugin.py
@@ -26,6 +26,7 @@ from .utils import (
     icon,
     log,
     run_cmd,
+    run_pip_install,
     warn,
 )
 
@@ -323,6 +324,8 @@ class Plugin:
             "--target",
             str(self.prefix_path),
             "--upgrade",
+            "--progress-bar",
+            "raw",
         ]
 
         # check to see if any dependencies have versions already installed - if it is, we need to propose a restart
@@ -331,13 +334,14 @@ class Plugin:
         )
 
         # run the installed command
-        run_cmd(
+        installed = run_pip_install(
             cmd,
+            reqs_to_install,
             f"installing {len(reqs_to_install)} requirements",
         )
 
         # if the package has been installed before, prompt user to restart
-        if already_installed:
+        if installed and already_installed:
             self.show_restart_message()
 
     def qpip_installed_packages(self):

--- a/a00_qpip/utils.py
+++ b/a00_qpip/utils.py
@@ -110,8 +110,10 @@ def run_cmd(args, description="running a system command"):
         )
 
 
-def run_pip_install(args, requirements, description="installing requirements"):
+def run_pip_install(args, requirements):
     """Run one pip install command with per-dependency progress reporting."""
+    requirement_label = "requirement" if len(requirements) == 1 else "requirements"
+    description = f"installing {len(requirements)} {requirement_label}"
     dialog = PipInstallProgressDialog(
         args,
         requirements,

--- a/a00_qpip/utils.py
+++ b/a00_qpip/utils.py
@@ -10,6 +10,8 @@ from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QMessageBox, QProgressDialog
 from qgis.utils import iface
 
+from .install_progress import PipInstallProgressDialog
+
 
 def log(message):
     QgsMessageLog.logMessage(message, "QPIP", level=Qgis.MessageLevel.Info)
@@ -106,3 +108,44 @@ def run_cmd(args, description="running a system command"):
             f"{description.capitalize()} succeeded",
             level=Qgis.Success,
         )
+
+
+def run_pip_install(args, requirements, description="installing requirements"):
+    """Run one pip install command with per-dependency progress reporting."""
+    dialog = PipInstallProgressDialog(
+        args,
+        requirements,
+        description,
+        log_callback=log,
+        parent=iface.mainWindow(),
+    )
+    return_code, cancelled, full_output = dialog.execute()
+
+    if return_code == 0:
+        log("Command succeeded.")
+        iface.messageBar().pushMessage(
+            "Success",
+            f"{description.capitalize()} succeeded",
+            level=Qgis.Success,
+        )
+        return True
+
+    if cancelled:
+        warn("Dependency installation was cancelled.")
+        iface.messageBar().pushMessage(
+            "Cancelled",
+            "Dependency installation was cancelled",
+            level=Qgis.Warning,
+        )
+        return False
+
+    warn("Command failed.")
+    message = QMessageBox(
+        QMessageBox.Icon.Warning,
+        "Command failed",
+        f"Encountered an error while {description} !",
+        parent=iface.mainWindow(),
+    )
+    message.setDetailedText(full_output)
+    message.exec()
+    return False

--- a/tests/test_install_progress.py
+++ b/tests/test_install_progress.py
@@ -1,7 +1,9 @@
 import sys
 
+import pytest
 from qgis.PyQt.QtCore import QTimer
 
+from a00_qpip import utils
 from a00_qpip.install_progress import PipInstallProgressDialog
 from a00_qpip.pip_progress import ProgressUpdate
 
@@ -54,3 +56,40 @@ def test_abort_kills_process_and_marks_dependency_cancelled(qgis_app):
     assert exit_code != 0
     assert cancelled
     assert dialog.table.item(row, 1).text() == "Cancelled"
+
+
+@pytest.mark.parametrize(
+    ("requirements", "expected_description"),
+    [
+        (["numpy>=2"], "installing 1 requirement"),
+        (["numpy>=2", "scipy>=1"], "installing 2 requirements"),
+    ],
+)
+def test_run_pip_install_builds_description_from_requirements(
+    monkeypatch, requirements, expected_description
+):
+    captured = {}
+
+    class FakeDialog:
+        def __init__(self, _args, _requirements, description, **_kwargs):
+            captured["description"] = description
+
+        def execute(self):
+            return 0, False, ""
+
+    class FakeMessageBar:
+        def pushMessage(self, *_args, **_kwargs):
+            pass
+
+    class FakeIface:
+        def mainWindow(self):
+            return None
+
+        def messageBar(self):
+            return FakeMessageBar()
+
+    monkeypatch.setattr(utils, "PipInstallProgressDialog", FakeDialog)
+    monkeypatch.setattr(utils, "iface", FakeIface())
+
+    assert utils.run_pip_install(["python", "-m", "pip"], requirements)
+    assert captured["description"] == expected_description

--- a/tests/test_install_progress.py
+++ b/tests/test_install_progress.py
@@ -1,0 +1,56 @@
+import sys
+
+from qgis.PyQt.QtCore import QTimer
+
+from a00_qpip.install_progress import PipInstallProgressDialog
+from a00_qpip.pip_progress import ProgressUpdate
+
+
+def make_dialog(qgis_app):
+    return PipInstallProgressDialog(
+        ["python", "-m", "pip", "--version"],
+        ["numpy>=2", "scipy>=1"],
+        "testing progress",
+        lambda _message: None,
+    )
+
+
+def test_download_bytes_are_scaled_to_percentage(qgis_app):
+    dialog = make_dialog(qgis_app)
+    dialog._apply_update(
+        ProgressUpdate("numpy", "Downloading", 3_000_000_000, 4_000_000_000)
+    )
+
+    _row, progress = dialog.rows["numpy"]
+    assert progress.maximum() == 100
+    assert progress.value() == 75
+
+
+def test_failure_marks_only_unfinished_dependencies(qgis_app):
+    dialog = make_dialog(qgis_app)
+    dialog._apply_update(ProgressUpdate("numpy", "Completed", 1, 1))
+    dialog._apply_update(ProgressUpdate("scipy", "Installing"))
+
+    dialog._mark_unfinished("Error")
+
+    numpy_row, _progress = dialog.rows["numpy"]
+    scipy_row, _progress = dialog.rows["scipy"]
+    assert dialog.table.item(numpy_row, 1).text() == "Completed"
+    assert dialog.table.item(scipy_row, 1).text() == "Error"
+
+
+def test_abort_kills_process_and_marks_dependency_cancelled(qgis_app):
+    dialog = PipInstallProgressDialog(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        ["numpy>=2"],
+        "testing cancellation",
+        lambda _message: None,
+    )
+    QTimer.singleShot(100, dialog._abort)
+
+    exit_code, cancelled, _output = dialog.execute()
+
+    row, _progress = dialog.rows["numpy"]
+    assert exit_code != 0
+    assert cancelled
+    assert dialog.table.item(row, 1).text() == "Cancelled"

--- a/tests/test_pip_progress.py
+++ b/tests/test_pip_progress.py
@@ -1,0 +1,60 @@
+from a00_qpip.pip_progress import (
+    PipProgressParser,
+    package_from_download,
+    requirement_name,
+)
+
+
+def test_requirement_name_handles_pep508_and_legacy_values():
+    assert requirement_name("harmonica>=0.7,<0.8") == "harmonica"
+    assert requirement_name("demo[extra] @ https://example.com/demo.whl") == "demo"
+
+
+def test_package_from_wheel_and_sdist_downloads():
+    assert package_from_download("numpy-2.2.6-cp311-cp311-win_amd64.whl") == "numpy"
+    assert package_from_download("https://example.com/scipy-1.17.1.tar.gz") == "scipy"
+
+
+def test_parser_tracks_raw_download_progress():
+    parser = PipProgressParser(["numpy==2.2.6"])
+
+    assert parser.parse_line("Collecting numpy==2.2.6")[0].status == "Resolving"
+    update = parser.parse_line(
+        "Downloading numpy-2.2.6-cp311-cp311-win_amd64.whl (12.9 MB)"
+    )[0]
+    assert update.package == "numpy"
+    assert update.status == "Downloading"
+
+    update = parser.parse_line("Progress 262144 of 12907455")[0]
+    assert (update.current, update.total) == (262144, 12907455)
+    assert update.status == "Downloading"
+
+    update = parser.parse_line("Progress 12907455 of 12907455")[0]
+    assert update.status == "Downloaded"
+
+
+def test_parser_discovers_transitive_packages_and_marks_install_complete():
+    parser = PipProgressParser(["harmonica>=0.7"])
+
+    update = parser.parse_line("Collecting xrft>=1.0 (from harmonica>=0.7)")[0]
+    assert update.package == "xrft"
+    assert update.status == "Resolving"
+
+    updates = parser.parse_line("Installing collected packages: xrft, harmonica")
+    assert [(update.package, update.status) for update in updates] == [
+        ("xrft", "Installing"),
+        ("harmonica", "Installing"),
+    ]
+
+    updates = parser.parse_line("Successfully installed harmonica-0.7.0 xrft-1.0.1")
+    assert all(update.status == "Completed" for update in updates)
+
+
+def test_parser_marks_satisfied_requirement_complete():
+    parser = PipProgressParser(["packaging>=23"])
+    update = parser.parse_line(
+        "Requirement already satisfied: packaging>=23 in C:/qgis/python (25.0)"
+    )[0]
+    assert update.package == "packaging"
+    assert update.status == "Already installed"
+    assert (update.current, update.total) == (1, 1)


### PR DESCRIPTION
## Summary
- replace the indeterminate install dialog with a QProcess-backed dependency table
- keep a single pip invocation so dependency resolution remains atomic
- parse pip's raw progress stream to show resolving, download, install, completed, cancelled, and error states per direct or transitive package
- add overall progress, cancellable execution, and an expandable full pip log
- scale byte counts to percentages so large downloads cannot overflow Qt progress bars
- only prompt for a QGIS restart after a successful install

This extends the generic progress work originally discussed in #1 with package-level progress.

## Validation
- 17 tests pass under QGIS 3.44.12 / Python 3.12 using pytest-qgis
- parser tests cover PEP 508 names, wheels, sdists, raw byte progress, transitive dependencies, install completion, and already-satisfied requirements
- GUI tests cover multi-gigabyte progress scaling, failed-row handling, and actual QProcess cancellation
- pre-commit passes on every changed file
- manual QGIS smoke: QProcess installed cowsay 6.1 into an isolated target, updated its row to Completed, and returned exit code 0
